### PR TITLE
Additional cleanup on ssh file transfers in the CPI

### DIFF
--- a/action/concrete_factory.go
+++ b/action/concrete_factory.go
@@ -4,7 +4,6 @@ import (
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
-	boshuuid "github.com/cloudfoundry/bosh-utils/uuid"
 
 	sl "github.com/maximilien/softlayer-go/softlayer"
 
@@ -18,7 +17,7 @@ type concreteFactory struct {
 	availableActions map[string]Action
 }
 
-func NewConcreteFactory(softLayerClient sl.Client, options ConcreteFactoryOptions, logger boshlog.Logger, uuidGenerator boshuuid.Generator, fs boshsys.FileSystem) concreteFactory {
+func NewConcreteFactory(softLayerClient sl.Client, options ConcreteFactoryOptions, logger boshlog.Logger, fs boshsys.FileSystem) concreteFactory {
 
 	stemcellFinder := bslcstem.NewSoftLayerFinder(softLayerClient, logger)
 
@@ -29,7 +28,6 @@ func NewConcreteFactory(softLayerClient sl.Client, options ConcreteFactoryOption
 		agentEnvServiceFactory,
 		options.Agent,
 		logger,
-		uuidGenerator,
 		fs,
 	)
 
@@ -37,8 +35,6 @@ func NewConcreteFactory(softLayerClient sl.Client, options ConcreteFactoryOption
 		softLayerClient,
 		agentEnvServiceFactory,
 		logger,
-		uuidGenerator,
-		fs,
 	)
 
 	bmCreator := bslcbm.NewBaremetalCreator(softLayerClient, logger)

--- a/action/concrete_factory_test.go
+++ b/action/concrete_factory_test.go
@@ -10,7 +10,6 @@ import (
 
 	fakecmd "github.com/cloudfoundry/bosh-utils/fileutil/fakes"
 	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
-	fakeuuid "github.com/cloudfoundry/bosh-utils/uuid/fakes"
 
 	fakeslclient "github.com/maximilien/softlayer-go/client/fakes"
 
@@ -23,7 +22,6 @@ var _ = Describe("concreteFactory", func() {
 	var (
 		softLayerClient *fakeslclient.FakeSoftLayerClient
 		fs              *fakesys.FakeFileSystem
-		uuidGenerator   *fakeuuid.FakeGenerator
 		cmdRunner       *fakesys.FakeCmdRunner
 		compressor      *fakecmd.FakeCompressor
 		logger          boshlog.Logger
@@ -53,7 +51,6 @@ var _ = Describe("concreteFactory", func() {
 			softLayerClient,
 			options,
 			logger,
-			uuidGenerator,
 			fs,
 		)
 	})
@@ -67,8 +64,6 @@ var _ = Describe("concreteFactory", func() {
 			softLayerClient,
 			agentEnvServiceFactory,
 			logger,
-			uuidGenerator,
-			fs,
 		)
 	})
 
@@ -93,7 +88,6 @@ var _ = Describe("concreteFactory", func() {
 				agentEnvServiceFactory,
 				options.Agent,
 				logger,
-				uuidGenerator,
 				fs,
 			)
 
@@ -145,8 +139,6 @@ var _ = Describe("concreteFactory", func() {
 				softLayerClient,
 				agentEnvServiceFactory,
 				logger,
-				uuidGenerator,
-				fs,
 			)
 			diskFinder = bslcdisk.NewSoftLayerDiskFinder(
 				softLayerClient,

--- a/main/main.go
+++ b/main/main.go
@@ -6,7 +6,6 @@ import (
 
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
-	boshuuid "github.com/cloudfoundry/bosh-utils/uuid"
 
 	slclient "github.com/maximilien/softlayer-go/client"
 
@@ -23,7 +22,7 @@ var (
 )
 
 func main() {
-	logger, fs, cmdRunner, uuidGenerator := basicDeps()
+	logger, fs, cmdRunner := basicDeps()
 
 	defer logger.HandlePanic("Main")
 
@@ -39,7 +38,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	dispatcher := buildDispatcher(config, logger, fs, cmdRunner, uuidGenerator)
+	dispatcher := buildDispatcher(config, logger, fs, cmdRunner)
 
 	cli := bslctrans.NewCLI(os.Stdin, os.Stdout, dispatcher, logger)
 
@@ -50,26 +49,23 @@ func main() {
 	}
 }
 
-func basicDeps() (boshlog.Logger, boshsys.FileSystem, boshsys.CmdRunner, boshuuid.Generator) {
+func basicDeps() (boshlog.Logger, boshsys.FileSystem, boshsys.CmdRunner) {
 	logger := boshlog.NewWriterLogger(boshlog.LevelDebug, os.Stderr, os.Stderr)
 
 	fs := boshsys.NewOsFileSystem(logger)
 
-	uuidGenerator := boshuuid.NewGenerator()
-
 	cmdRunner := boshsys.NewExecCmdRunner(logger)
 
-	return logger, fs, cmdRunner, uuidGenerator
+	return logger, fs, cmdRunner
 }
 
-func buildDispatcher(config Config, logger boshlog.Logger, fs boshsys.FileSystem, cmdRunner boshsys.CmdRunner, uuidGenerator boshuuid.Generator) bslcdisp.Dispatcher {
+func buildDispatcher(config Config, logger boshlog.Logger, fs boshsys.FileSystem, cmdRunner boshsys.CmdRunner) bslcdisp.Dispatcher {
 	softLayerClient := slclient.NewSoftLayerClient(config.Cloud.Properties.Softlayer.Username, config.Cloud.Properties.Softlayer.ApiKey)
 
 	actionFactory := bslcaction.NewConcreteFactory(
 		softLayerClient,
 		config.Cloud.Properties,
 		logger,
-		uuidGenerator,
 		fs,
 	)
 

--- a/softlayer/vm/softlayer_creator.go
+++ b/softlayer/vm/softlayer_creator.go
@@ -13,7 +13,6 @@ import (
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
-	boshuuid "github.com/cloudfoundry/bosh-utils/uuid"
 
 	bslcommon "github.com/cloudfoundry/bosh-softlayer-cpi/softlayer/common"
 	bslcstem "github.com/cloudfoundry/bosh-softlayer-cpi/softlayer/stemcell"
@@ -30,13 +29,12 @@ type SoftLayerCreator struct {
 	softLayerClient        sl.Client
 	agentEnvServiceFactory AgentEnvServiceFactory
 
-	agentOptions  AgentOptions
-	logger        boshlog.Logger
-	uuidGenerator boshuuid.Generator
-	fs            boshsys.FileSystem
+	agentOptions AgentOptions
+	logger       boshlog.Logger
+	fs           boshsys.FileSystem
 }
 
-func NewSoftLayerCreator(softLayerClient sl.Client, agentEnvServiceFactory AgentEnvServiceFactory, agentOptions AgentOptions, logger boshlog.Logger, uuidGenerator boshuuid.Generator, fs boshsys.FileSystem) SoftLayerCreator {
+func NewSoftLayerCreator(softLayerClient sl.Client, agentEnvServiceFactory AgentEnvServiceFactory, agentOptions AgentOptions, logger boshlog.Logger, fs boshsys.FileSystem) SoftLayerCreator {
 	bslcommon.TIMEOUT = 120 * time.Minute
 	bslcommon.POLLING_INTERVAL = 5 * time.Second
 
@@ -45,7 +43,6 @@ func NewSoftLayerCreator(softLayerClient sl.Client, agentEnvServiceFactory Agent
 		agentEnvServiceFactory: agentEnvServiceFactory,
 		agentOptions:           agentOptions,
 		logger:                 logger,
-		uuidGenerator:          uuidGenerator,
 		fs:                     fs,
 	}
 }
@@ -85,7 +82,7 @@ func (c SoftLayerCreator) CreateBySoftlayer(agentID string, stemcell bslcstem.St
 		return SoftLayerVM{}, bosherr.WrapErrorf(err, "Cannot get details from virtual guest with id: %d.", virtualGuest.Id)
 	}
 
-	softlayerFileService := NewSoftlayerFileService(util.GetSshClient(), virtualGuest, c.logger, c.uuidGenerator, c.fs)
+	softlayerFileService := NewSoftlayerFileService(util.GetSshClient(), virtualGuest, c.logger)
 	agentEnvService := c.agentEnvServiceFactory.New(softlayerFileService, strconv.Itoa(virtualGuest.Id))
 
 	if len(cloudProps.BoshIp) == 0 {
@@ -179,7 +176,7 @@ func (c SoftLayerCreator) CreateByOSReload(agentID string, stemcell bslcstem.Ste
 		return SoftLayerVM{}, bosherr.WrapErrorf(err, "Cannot get details from virtual guest with id: %d.", virtualGuest.Id)
 	}
 
-	softlayerFileService := NewSoftlayerFileService(util.GetSshClient(), virtualGuest, c.logger, c.uuidGenerator, c.fs)
+	softlayerFileService := NewSoftlayerFileService(util.GetSshClient(), virtualGuest, c.logger)
 	agentEnvService := c.agentEnvServiceFactory.New(softlayerFileService, strconv.Itoa(virtualGuest.Id))
 
 	if len(cloudProps.BoshIp) == 0 {

--- a/softlayer/vm/softlayer_creator_test.go
+++ b/softlayer/vm/softlayer_creator_test.go
@@ -15,7 +15,6 @@ import (
 	fakevm "github.com/cloudfoundry/bosh-softlayer-cpi/softlayer/vm/fakes"
 	fakesutil "github.com/cloudfoundry/bosh-softlayer-cpi/util/fakes"
 	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
-	fakeuuid "github.com/cloudfoundry/bosh-utils/uuid/fakes"
 
 	fakeslclient "github.com/maximilien/softlayer-go/client/fakes"
 
@@ -33,7 +32,6 @@ var _ = Describe("SoftLayerCreator", func() {
 		sshClient              *fakesutil.FakeSshClient
 		agentEnvServiceFactory *fakevm.FakeAgentEnvServiceFactory
 		fs                     *fakesys.FakeFileSystem
-		uuidGenerator          *fakeuuid.FakeGenerator
 		agentOptions           AgentOptions
 		logger                 boshlog.Logger
 		creator                SoftLayerCreator
@@ -42,7 +40,6 @@ var _ = Describe("SoftLayerCreator", func() {
 	BeforeEach(func() {
 		softLayerClient = fakeslclient.NewFakeSoftLayerClient("fake-username", "fake-api-key")
 		sshClient = &fakesutil.FakeSshClient{}
-		uuidGenerator = fakeuuid.NewFakeGenerator()
 		fs = fakesys.NewFakeFileSystem()
 		agentEnvServiceFactory = &fakevm.FakeAgentEnvServiceFactory{}
 		agentOptions = AgentOptions{Mbus: "fake-mbus"}
@@ -53,7 +50,6 @@ var _ = Describe("SoftLayerCreator", func() {
 			agentEnvServiceFactory,
 			agentOptions,
 			logger,
-			uuidGenerator,
 			fs,
 		)
 		bslcommon.TIMEOUT = 2 * time.Second

--- a/softlayer/vm/softlayer_finder.go
+++ b/softlayer/vm/softlayer_finder.go
@@ -6,8 +6,6 @@ import (
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
-	boshsys "github.com/cloudfoundry/bosh-utils/system"
-	boshuuid "github.com/cloudfoundry/bosh-utils/uuid"
 
 	util "github.com/cloudfoundry/bosh-softlayer-cpi/util"
 	sl "github.com/maximilien/softlayer-go/softlayer"
@@ -19,17 +17,13 @@ type SoftLayerFinder struct {
 	softLayerClient        sl.Client
 	agentEnvServiceFactory AgentEnvServiceFactory
 	logger                 boshlog.Logger
-	uuidGenerator          boshuuid.Generator
-	fs                     boshsys.FileSystem
 }
 
-func NewSoftLayerFinder(softLayerClient sl.Client, agentEnvServiceFactory AgentEnvServiceFactory, logger boshlog.Logger, uuidGenerator boshuuid.Generator, fs boshsys.FileSystem) SoftLayerFinder {
+func NewSoftLayerFinder(softLayerClient sl.Client, agentEnvServiceFactory AgentEnvServiceFactory, logger boshlog.Logger) SoftLayerFinder {
 	return SoftLayerFinder{
 		softLayerClient:        softLayerClient,
 		agentEnvServiceFactory: agentEnvServiceFactory,
 		logger:                 logger,
-		uuidGenerator:          uuidGenerator,
-		fs:                     fs,
 	}
 }
 
@@ -48,7 +42,7 @@ func (f SoftLayerFinder) Find(vmID int) (VM, bool, error) {
 
 	vm, found := SoftLayerVM{}, true
 	if virtualGuest.Id == vmID {
-		softlayerFileService := NewSoftlayerFileService(util.GetSshClient(), virtualGuest, f.logger, f.uuidGenerator, f.fs)
+		softlayerFileService := NewSoftlayerFileService(util.GetSshClient(), virtualGuest, f.logger)
 		vm = NewSoftLayerVM(vmID, f.softLayerClient, util.GetSshClient(), f.agentEnvServiceFactory.New(softlayerFileService, strconv.Itoa(vmID)), f.logger)
 	} else {
 		found = false

--- a/softlayer/vm/softlayer_finder_test.go
+++ b/softlayer/vm/softlayer_finder_test.go
@@ -12,7 +12,6 @@ import (
 
 	fakevm "github.com/cloudfoundry/bosh-softlayer-cpi/softlayer/vm/fakes"
 	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
-	fakeuuid "github.com/cloudfoundry/bosh-utils/uuid/fakes"
 	fakeslclient "github.com/maximilien/softlayer-go/client/fakes"
 )
 
@@ -21,25 +20,17 @@ var _ = Describe("SoftLayerFinder", func() {
 		softLayerClient        *fakeslclient.FakeSoftLayerClient
 		agentEnvServiceFactory *fakevm.FakeAgentEnvServiceFactory
 		fs                     *fakesys.FakeFileSystem
-		uuidGenerator          *fakeuuid.FakeGenerator
 		logger                 boshlog.Logger
 		finder                 SoftLayerFinder
 	)
 
 	BeforeEach(func() {
 		softLayerClient = fakeslclient.NewFakeSoftLayerClient("fake-username", "fake-api-key")
-		uuidGenerator = fakeuuid.NewFakeGenerator()
 		fs = fakesys.NewFakeFileSystem()
 		agentEnvServiceFactory = &fakevm.FakeAgentEnvServiceFactory{}
 		logger = boshlog.NewLogger(boshlog.LevelNone)
 
-		finder = NewSoftLayerFinder(
-			softLayerClient,
-			agentEnvServiceFactory,
-			logger,
-			uuidGenerator,
-			fs,
-		)
+		finder = NewSoftLayerFinder(softLayerClient, agentEnvServiceFactory, logger)
 
 		testhelpers.SetTestFixtureForFakeSoftLayerClient(softLayerClient, "SoftLayer_Virtual_Guest_Service_getObject.json")
 	})


### PR DESCRIPTION
Provided #122 is merged, this is additional cleanup to use the new upload and download methods without intermediate temporary files. This adds some test coverage to the file service and removes some dependencies.