### PR TITLE
Change to use 3 valued bool for LocalDiskFlag

### DIFF
--- a/Godeps/_workspace/src/github.com/maximilien/softlayer-go/data_types/softlayer_virtual_guest.go
+++ b/Godeps/_workspace/src/github.com/maximilien/softlayer-go/data_types/softlayer_virtual_guest.go
@@ -29,7 +29,7 @@ type SoftLayer_Virtual_Guest struct {
 	StartCpus                    int        `json:"startCpus,omitempty"`
 	StatusId                     int        `json:"statusId,omitempty"`
 	Uuid                         string     `json:"uuid,omitempty"`
-	LocalDiskFlag                bool       `json:"localDiskFlag,omitempty"`
+	LocalDiskFlag                *bool       `json:"localDiskFlag,omitempty"`
 	HourlyBillingFlag            bool       `json:"hourlyBillingFlag,omitempty"`
 
 	GlobalIdentifier        string `json:"globalIdentifier,omitempty"`
@@ -71,7 +71,7 @@ type SoftLayer_Virtual_Guest_Template struct {
 	MaxMemory         int        `json:"maxMemory"`
 	Datacenter        Datacenter `json:"datacenter"`
 	HourlyBillingFlag bool       `json:"hourlyBillingFlag"`
-	LocalDiskFlag     bool       `json:"localDiskFlag"`
+	LocalDiskFlag     *bool       `json:"localDiskFlag"`
 
 	//Conditionally required
 	OperatingSystemReferenceCode string                    `json:"operatingSystemReferenceCode,omitempty"`

--- a/Godeps/_workspace/src/github.com/maximilien/softlayer-go/test_helpers/test_helpers.go
+++ b/Godeps/_workspace/src/github.com/maximilien/softlayer-go/test_helpers/test_helpers.go
@@ -373,6 +373,8 @@ func CreateVirtualGuestAndMarkItTest(securitySshKeys []datatypes.SoftLayer_Secur
 	for i, securitySshKey := range securitySshKeys {
 		sshKeys[i] = datatypes.SshKey{Id: securitySshKey.Id}
 	}
+	t := new(bool)
+	*t = true
 
 	virtualGuestTemplate := datatypes.SoftLayer_Virtual_Guest_Template{
 		Hostname:  "test",
@@ -384,7 +386,7 @@ func CreateVirtualGuestAndMarkItTest(securitySshKeys []datatypes.SoftLayer_Secur
 		},
 		SshKeys:                      sshKeys,
 		HourlyBillingFlag:            true,
-		LocalDiskFlag:                true,
+		LocalDiskFlag:                t,
 		OperatingSystemReferenceCode: "UBUNTU_LATEST",
 	}
 

--- a/action/create_vm.go
+++ b/action/create_vm.go
@@ -93,4 +93,8 @@ func (a CreateVMAction) UpdateCloudProperties(cloudProps *bslcvm.VMCloudProperti
 	if len(cloudProps.NetworkComponents) == 0 {
 		a.vmCloudProperties.NetworkComponents = []sldatatypes.NetworkComponents{{MaxSpeed: 1000}}
 	}
+	if cloudProps.LocalDiskFlag == nil {
+		a.vmCloudProperties.LocalDiskFlag = new(bool)
+		*a.vmCloudProperties.LocalDiskFlag = true
+	}
 }

--- a/action/create_vm_test.go
+++ b/action/create_vm_test.go
@@ -91,6 +91,11 @@ var _ = Describe("CreateVM", func() {
 
 				_, err := action.Run("fake-agent-id", stemcellCID, vmCloudProp2, networks, diskLocality, env)
 				Expect(err).ToNot(HaveOccurred())
+
+				action.UpdateCloudProperties(&vmCloudProp2)
+				t := new(bool)
+				*t = true
+				Expect(vmCloudProp2.LocalDiskFlag).To(Equal(t))
 			})
 		})
 

--- a/integration/create_vm/create_vm_test.go
+++ b/integration/create_vm/create_vm_test.go
@@ -40,11 +40,9 @@ var _ = Describe("BOSH Director Level Integration for create_vm", func() {
 
 	BeforeEach(func() {
 		username = os.Getenv("SL_USERNAME")
-		fmt.Println(username)
 		Expect(username).ToNot(Equal(""), "username cannot be empty, set SL_USERNAME")
 
 		apiKey = os.Getenv("SL_API_KEY")
-		fmt.Println(apiKey)
 		Expect(apiKey).ToNot(Equal(""), "apiKey cannot be empty, set SL_API_KEY")
 
 		client = slclient.NewSoftLayerClient(username, apiKey)

--- a/integration/create_vm/create_vm_test.go
+++ b/integration/create_vm/create_vm_test.go
@@ -12,6 +12,7 @@ import (
 
 	"log"
 
+	"fmt"
 	testhelperscpi "github.com/cloudfoundry/bosh-softlayer-cpi/test_helpers"
 	slclient "github.com/maximilien/softlayer-go/client"
 	softlayer "github.com/maximilien/softlayer-go/softlayer"
@@ -39,9 +40,11 @@ var _ = Describe("BOSH Director Level Integration for create_vm", func() {
 
 	BeforeEach(func() {
 		username = os.Getenv("SL_USERNAME")
+		fmt.Println(username)
 		Expect(username).ToNot(Equal(""), "username cannot be empty, set SL_USERNAME")
 
 		apiKey = os.Getenv("SL_API_KEY")
+		fmt.Println(apiKey)
 		Expect(apiKey).ToNot(Equal(""), "apiKey cannot be empty, set SL_API_KEY")
 
 		client = slclient.NewSoftLayerClient(username, apiKey)

--- a/softlayer/vm/interface.go
+++ b/softlayer/vm/interface.go
@@ -19,7 +19,7 @@ type VMCloudProperties struct {
 	EphemeralDiskSize        int                                  `json:"ephemeralDiskSize,omitempty"`
 
 	HourlyBillingFlag              bool                                       `json:"hourlyBillingFlag,omitempty"`
-	LocalDiskFlag                  bool                                       `json:"localDiskFlag,omitempty"`
+	LocalDiskFlag                  *bool                                      `json:"localDiskFlag,omitempty"`
 	DedicatedAccountHostOnlyFlag   bool                                       `json:"dedicatedAccountHostOnlyFlag,omitempty"`
 	NetworkComponents              []sldatatypes.NetworkComponents            `json:"networkComponents,omitempty"`
 	PrivateNetworkOnlyFlag         bool                                       `json:"privateNetworkOnlyFlag,omitempty"`

--- a/softlayer/vm/softlayer_hardware_creator_test.go
+++ b/softlayer/vm/softlayer_hardware_creator_test.go
@@ -62,6 +62,8 @@ var _ = Describe("SoftLayer_Hardware_Creator", func() {
 			networks   Networks
 			env        Environment
 		)
+		t := new(bool)
+		*t = true
 
 		Context("valid arguments", func() {
 			BeforeEach(func() {
@@ -106,7 +108,7 @@ var _ = Describe("SoftLayer_Hardware_Creator", func() {
 							BoshIp:                       "10.0.0.1",
 							Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
 							HourlyBillingFlag:            true,
-							LocalDiskFlag:                true,
+							LocalDiskFlag:                t,
 							VmNamePrefix:                 "bosh-test",
 							PostInstallScriptUri:         "",
 							DedicatedAccountHostOnlyFlag: true,
@@ -180,7 +182,7 @@ var _ = Describe("SoftLayer_Hardware_Creator", func() {
 							EphemeralDiskSize:            25,
 							Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
 							HourlyBillingFlag:            true,
-							LocalDiskFlag:                true,
+							LocalDiskFlag:                t,
 							VmNamePrefix:                 "bosh-",
 							PostInstallScriptUri:         "",
 							DedicatedAccountHostOnlyFlag: true,

--- a/softlayer/vm/softlayer_virtual_guest_creator_test.go
+++ b/softlayer/vm/softlayer_virtual_guest_creator_test.go
@@ -56,6 +56,8 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 			networks   Networks
 			env        Environment
 		)
+		t := new(bool)
+		*t = true
 
 		Context("valid arguments", func() {
 			BeforeEach(func() {
@@ -101,7 +103,7 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 							EphemeralDiskSize:            25,
 							Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
 							HourlyBillingFlag:            true,
-							LocalDiskFlag:                true,
+							LocalDiskFlag:                t,
 							VmNamePrefix:                 "bosh-test",
 							PostInstallScriptUri:         "",
 							DedicatedAccountHostOnlyFlag: true,
@@ -141,7 +143,7 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 							BoshIp:                       "10.0.0.1",
 							Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
 							HourlyBillingFlag:            true,
-							LocalDiskFlag:                true,
+							LocalDiskFlag:                t,
 							VmNamePrefix:                 "bosh-test",
 							PostInstallScriptUri:         "",
 							DedicatedAccountHostOnlyFlag: true,
@@ -179,7 +181,7 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 							EphemeralDiskSize:            25,
 							Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
 							HourlyBillingFlag:            true,
-							LocalDiskFlag:                true,
+							LocalDiskFlag:                t,
 							VmNamePrefix:                 "bosh-",
 							PostInstallScriptUri:         "",
 							DedicatedAccountHostOnlyFlag: true,
@@ -242,7 +244,7 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 							EphemeralDiskSize:            25,
 							Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
 							HourlyBillingFlag:            true,
-							LocalDiskFlag:                true,
+							LocalDiskFlag:                t,
 							VmNamePrefix:                 "bosh-test",
 							PostInstallScriptUri:         "",
 							DedicatedAccountHostOnlyFlag: true,
@@ -281,7 +283,7 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 							BoshIp:                       "10.0.0.1",
 							Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
 							HourlyBillingFlag:            true,
-							LocalDiskFlag:                true,
+							LocalDiskFlag:                t,
 							VmNamePrefix:                 "bosh-test",
 							PostInstallScriptUri:         "",
 							DedicatedAccountHostOnlyFlag: true,
@@ -319,7 +321,7 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 							EphemeralDiskSize:            25,
 							Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
 							HourlyBillingFlag:            true,
-							LocalDiskFlag:                true,
+							LocalDiskFlag:                t,
 							VmNamePrefix:                 "bosh-",
 							PostInstallScriptUri:         "",
 							DedicatedAccountHostOnlyFlag: true,

--- a/softlayer/vm/vm_utils_test.go
+++ b/softlayer/vm/vm_utils_test.go
@@ -24,6 +24,8 @@ var _ = Describe("VM Utils", func() {
 		softLayerClient *fakeslclient.FakeSoftLayerClient
 		logger          boshlog.Logger
 	)
+	t := new(bool)
+	*t = true
 
 	BeforeEach(func() {
 		softLayerClient = fakeslclient.NewFakeSoftLayerClient("fake-username", "fake-api-key")
@@ -145,7 +147,7 @@ var _ = Describe("VM Utils", func() {
 				EphemeralDiskSize:            25,
 				Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
 				HourlyBillingFlag:            true,
-				LocalDiskFlag:                true,
+				LocalDiskFlag:                t,
 				VmNamePrefix:                 "bosh-",
 				PostInstallScriptUri:         "",
 				DedicatedAccountHostOnlyFlag: true,
@@ -176,7 +178,7 @@ var _ = Describe("VM Utils", func() {
 				},
 
 				HourlyBillingFlag:            true,
-				LocalDiskFlag:                true,
+				LocalDiskFlag:                t,
 				OperatingSystemReferenceCode: "",
 
 				BlockDeviceTemplateGroup: &sldatatypes.BlockDeviceTemplateGroup{

--- a/test_fixtures/cpi_methods/create_vm.json
+++ b/test_fixtures/cpi_methods/create_vm.json
@@ -2,14 +2,13 @@
 	"method": "create_vm",
 	"arguments": [
 		"45632666-9fb1-422a-af35-2ab6102c5c1b",
-		"879741",
+		"1217085",
 		{
 			"vmNamePrefix": "ecpi-test",
 			"domain": "softlayer.com",
 			"startCpus": 1,
 			"maxMemory": 1024,
 			"hourlyBillingFlag": true,
-			"localDiskFlag": true,
 			"dedicatedAccountHostOnlyFlag": false,
 			"datacenter": {
 				"name": "lon02"


### PR DESCRIPTION
For addressing [Tracker 126049889](https://www.pivotaltracker.com/story/show/126049889), basically, we want to set true to LocalDiskFlag if it's not specified in the deployment manifest.