### PR TITLE
Print out warning msg if length of hostname > 64

### DIFF
--- a/action/create_vm.go
+++ b/action/create_vm.go
@@ -90,6 +90,8 @@ func (a CreateVMAction) UpdateCloudProperties(cloudProps *bslcvm.VMCloudProperti
 	if len(cloudProps.Domain) == 0 {
 		a.vmCloudProperties.Domain = "softlayer.com"
 	}
+	bslcommon.LengthOfHostName = len(a.vmCloudProperties.VmNamePrefix + "." + a.vmCloudProperties.Domain)
+
 	if len(cloudProps.NetworkComponents) == 0 {
 		a.vmCloudProperties.NetworkComponents = []sldatatypes.NetworkComponents{{MaxSpeed: 1000}}
 	}

--- a/action/create_vm_test.go
+++ b/action/create_vm_test.go
@@ -11,6 +11,7 @@ import (
 
 	fakestem "github.com/cloudfoundry/bosh-softlayer-cpi/softlayer/stemcell/fakes"
 
+	bslcommon "github.com/cloudfoundry/bosh-softlayer-cpi/softlayer/common"
 	bslcvm "github.com/cloudfoundry/bosh-softlayer-cpi/softlayer/vm"
 
 	sldatatypes "github.com/maximilien/softlayer-go/data_types"
@@ -43,9 +44,13 @@ var _ = Describe("CreateVM", func() {
 		BeforeEach(func() {
 			stemcellCID = StemcellCID(1234)
 			vmCloudProp = bslcvm.VMCloudProperties{
-				StartCpus:  2,
-				MaxMemory:  2048,
-				Datacenter: sldatatypes.Datacenter{Name: "fake-datacenter"},
+				StartCpus:    2,
+				MaxMemory:    2048,
+				VmNamePrefix: "fake-hostname",
+				Domain:       "softlayer.com",
+				Baremetal:    false,
+				BoshIp:       "10.0.0.0.0",
+				Datacenter:   sldatatypes.Datacenter{Name: "fake-datacenter"},
 				SshKeys: []sldatatypes.SshKey{
 					sldatatypes.SshKey{Id: 1234},
 				},
@@ -74,6 +79,7 @@ var _ = Describe("CreateVM", func() {
 				id, err := action.Run("fake-agent-id", stemcellCID, vmCloudProp, networks, diskLocality, env)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(id).To(Equal(VMCID(1234).String()))
+				Expect(bslcommon.LengthOfHostName).To(Equal(46))
 			})
 
 			It("creates VM with requested agent ID, stemcell, cloud properties, and networks", func() {

--- a/softlayer/common/softlayer_helper.go
+++ b/softlayer/common/softlayer_helper.go
@@ -17,6 +17,9 @@ var (
 	TIMEOUT             time.Duration
 	POLLING_INTERVAL    time.Duration
 	LocalDiskFlagNotSet bool
+	LengthOfHostName    int
+	RETRY_COUNT         int
+	WAIT_TIME           time.Duration
 )
 
 type SoftLayer_Hardware_Parameters struct {

--- a/softlayer/vm/softlayer_hardware.go
+++ b/softlayer/vm/softlayer_hardware.go
@@ -149,6 +149,8 @@ func (vm *softLayerHardware) ConfigureNetworks(networks Networks) error {
 	}
 
 	oldAgentEnv.Networks = networks
+	bslcommon.RETRY_COUNT = 30
+	bslcommon.WAIT_TIME = 5 * time.Second
 	err = vm.agentEnvService.Update(oldAgentEnv)
 	if err != nil {
 		return bosherr.WrapError(err, fmt.Sprintf("Configuring network setting on hardware with id: `%d`", vm.ID()))
@@ -214,6 +216,8 @@ func (vm *softLayerHardware) AttachDisk(disk bslcdisk.Disk) error {
 	}
 
 	err = vm.agentEnvService.Update(newAgentEnv)
+	bslcommon.RETRY_COUNT = 30
+	bslcommon.WAIT_TIME = 5 * time.Second
 	if err != nil {
 		return bosherr.WrapError(err, fmt.Sprintf("Configuring userdata on hardware with id: `%d`", vm.ID()))
 	}
@@ -256,6 +260,8 @@ func (vm *softLayerHardware) DetachDisk(disk bslcdisk.Disk) error {
 	}
 
 	newAgentEnv := oldAgentEnv.DetachPersistentDisk(strconv.Itoa(disk.ID()))
+	bslcommon.RETRY_COUNT = 30
+	bslcommon.WAIT_TIME = 5 * time.Second
 	err = vm.agentEnvService.Update(newAgentEnv)
 	if err != nil {
 		return bosherr.WrapError(err, fmt.Sprintf("Configuring userdata on hardware with id: `%d`", vm.ID()))
@@ -291,6 +297,8 @@ func (vm *softLayerHardware) DetachDisk(disk bslcdisk.Disk) error {
 }
 
 func (vm *softLayerHardware) UpdateAgentEnv(agentEnv AgentEnv) error {
+	bslcommon.RETRY_COUNT = 30
+	bslcommon.WAIT_TIME = 5 * time.Second
 	return vm.agentEnvService.Update(agentEnv)
 }
 

--- a/softlayer/vm/softlayer_virtual_guest.go
+++ b/softlayer/vm/softlayer_virtual_guest.go
@@ -218,6 +218,8 @@ func (vm *softLayerVirtualGuest) ConfigureNetworks(networks Networks) error {
 	}
 
 	oldAgentEnv.Networks = networks
+	bslcommon.RETRY_COUNT = 30
+	bslcommon.WAIT_TIME = 5 * time.Second
 	err = vm.agentEnvService.Update(oldAgentEnv)
 	if err != nil {
 		return bosherr.WrapError(err, fmt.Sprintf("Configuring network setting on VirtualGuest with id: `%d`", vm.ID()))
@@ -282,6 +284,8 @@ func (vm *softLayerVirtualGuest) AttachDisk(disk bslcdisk.Disk) error {
 		newAgentEnv = oldAgentEnv.AttachPersistentDisk(strconv.Itoa(disk.ID()), "/dev/"+deviceName)
 	}
 
+	bslcommon.RETRY_COUNT = 30
+	bslcommon.WAIT_TIME = 5 * time.Second
 	err = vm.agentEnvService.Update(newAgentEnv)
 	if err != nil {
 		return bosherr.WrapError(err, fmt.Sprintf("Configuring userdata on VirtualGuest with id: `%d`", vm.ID()))
@@ -360,6 +364,8 @@ func (vm *softLayerVirtualGuest) DetachDisk(disk bslcdisk.Disk) error {
 }
 
 func (vm *softLayerVirtualGuest) UpdateAgentEnv(agentEnv AgentEnv) error {
+	bslcommon.RETRY_COUNT = 30
+	bslcommon.WAIT_TIME = 5 * time.Second
 	return vm.agentEnvService.Update(agentEnv)
 }
 


### PR DESCRIPTION
This PR is for addressing [issue 129](https://github.com/cloudfoundry/bosh-softlayer-cpi/issues/129), if the deployment fails due to the long hostname, the place where fails at first is to try to upload agent env to the target VM over SSH. So I added warning messages in the code where to upload agent env. I also added unit test. @maximilien, this PR is ready for review. Thanks.