### PR TITLE
Disable os_reload function

### DIFF
--- a/action/concrete_factory_options.go
+++ b/action/concrete_factory_options.go
@@ -18,8 +18,6 @@ type ConcreteFactoryOptions struct {
 	AgentEnvService string `json:"agentenvservice,omitempty"`
 
 	Registry bslcvm.RegistryOptions `json:"registry,omitempty"`
-
-	DisableOsReload bool `json:"disableOsReload,omitempty"`
 }
 
 func (o ConcreteFactoryOptions) Validate() error {
@@ -37,8 +35,9 @@ func (o ConcreteFactoryOptions) Validate() error {
 }
 
 type SoftLayerConfig struct {
-	Username string `json:"username"`
-	ApiKey   string `json:"apiKey"`
+	Username        string `json:"username"`
+	ApiKey          string `json:"apiKey"`
+	DisableOsReload bool   `json:"disableOsReload,omitempty"`
 }
 
 type BaremetalConfig struct {

--- a/action/concrete_factory_options.go
+++ b/action/concrete_factory_options.go
@@ -35,9 +35,9 @@ func (o ConcreteFactoryOptions) Validate() error {
 }
 
 type SoftLayerConfig struct {
-	Username        string `json:"username"`
-	ApiKey          string `json:"apiKey"`
-	DisableOsReload bool   `json:"disableOsReload,omitempty"`
+	Username       string                `json:"username"`
+	ApiKey         string                `json:"apiKey"`
+	FeatureOptions bslcvm.FeatureOptions `json:"featureOptions"`
 }
 
 type BaremetalConfig struct {

--- a/action/concrete_factory_options.go
+++ b/action/concrete_factory_options.go
@@ -18,6 +18,8 @@ type ConcreteFactoryOptions struct {
 	AgentEnvService string `json:"agentenvservice,omitempty"`
 
 	Registry bslcvm.RegistryOptions `json:"registry,omitempty"`
+
+	DisableOsReload bool `json:"disableOsReload,omitempty"`
 }
 
 func (o ConcreteFactoryOptions) Validate() error {

--- a/action/provider.go
+++ b/action/provider.go
@@ -33,7 +33,7 @@ func NewProvider(softLayerClient sl.Client, baremetalClient bmscl.BmpClient, opt
 		softLayerClient,
 		options.Agent,
 		logger,
-		options.Softlayer.DisableOsReload,
+		options.Softlayer.FeatureOptions,
 	)
 
 	baremetalCreator := bslcvm.NewBaremetalCreator(

--- a/action/provider.go
+++ b/action/provider.go
@@ -33,6 +33,7 @@ func NewProvider(softLayerClient sl.Client, baremetalClient bmscl.BmpClient, opt
 		softLayerClient,
 		options.Agent,
 		logger,
+		options.DisableOsReload,
 	)
 
 	baremetalCreator := bslcvm.NewBaremetalCreator(

--- a/action/provider.go
+++ b/action/provider.go
@@ -33,7 +33,7 @@ func NewProvider(softLayerClient sl.Client, baremetalClient bmscl.BmpClient, opt
 		softLayerClient,
 		options.Agent,
 		logger,
-		options.DisableOsReload,
+		options.Softlayer.DisableOsReload,
 	)
 
 	baremetalCreator := bslcvm.NewBaremetalCreator(

--- a/api/dispatcher/json.go
+++ b/api/dispatcher/json.go
@@ -179,6 +179,6 @@ func (c JSON) localDiskFlagNotSet(reqString string) {
 		bslcommon.LocalDiskFlagNotSet = false
 	} else {
 		bslcommon.LocalDiskFlagNotSet = true
-	//	c.logger.DebugWithDetails(jsonLogTag, "localDiskFlag is not specified in the input json, will set true as the default value", "")
+		//	c.logger.DebugWithDetails(jsonLogTag, "localDiskFlag is not specified in the input json, will set true as the default value", "")
 	}
 }

--- a/api/dispatcher/json.go
+++ b/api/dispatcher/json.go
@@ -179,6 +179,5 @@ func (c JSON) localDiskFlagNotSet(reqString string) {
 		bslcommon.LocalDiskFlagNotSet = false
 	} else {
 		bslcommon.LocalDiskFlagNotSet = true
-		//	c.logger.DebugWithDetails(jsonLogTag, "localDiskFlag is not specified in the input json, will set true as the default value", "")
 	}
 }

--- a/softlayer/vm/interface.go
+++ b/softlayer/vm/interface.go
@@ -34,6 +34,8 @@ type VMCloudProperties struct {
 	Baremetal             bool   `json:"baremetal,omitempty"`
 	BaremetalStemcell     string `json:"bm_stemcell,omitempty"`
 	BaremetalNetbootImage string `json:"bm_netboot_image,omitempty"`
+
+	DisableOsReload bool `json:"disableOsReload,omitempty"`
 }
 
 type AllowedHostCredential struct {

--- a/softlayer/vm/interface.go
+++ b/softlayer/vm/interface.go
@@ -7,6 +7,10 @@ import (
 	sldatatypes "github.com/maximilien/softlayer-go/data_types"
 )
 
+type FeatureOptions struct {
+	DisableOsReload bool `json:"disableOsReload"`
+}
+
 type VMCloudProperties struct {
 	VmNamePrefix             string                               `json:"vmNamePrefix,omitempty"`
 	Domain                   string                               `json:"domain,omitempty"`

--- a/softlayer/vm/softlayer_virtual_guest_creator.go
+++ b/softlayer/vm/softlayer_virtual_guest_creator.go
@@ -26,10 +26,10 @@ type softLayerVirtualGuestCreator struct {
 	logger       boshlog.Logger
 	vmFinder     Finder
 
-	disableOsReload bool
+	featureOptions FeatureOptions
 }
 
-func NewSoftLayerCreator(vmFinder Finder, softLayerClient sl.Client, agentOptions AgentOptions, logger boshlog.Logger, disableOsReload bool) VMCreator {
+func NewSoftLayerCreator(vmFinder Finder, softLayerClient sl.Client, agentOptions AgentOptions, logger boshlog.Logger, featureOptions FeatureOptions) VMCreator {
 	bslcommon.TIMEOUT = 120 * time.Minute
 	bslcommon.POLLING_INTERVAL = 5 * time.Second
 
@@ -38,7 +38,7 @@ func NewSoftLayerCreator(vmFinder Finder, softLayerClient sl.Client, agentOption
 		softLayerClient: softLayerClient,
 		agentOptions:    agentOptions,
 		logger:          logger,
-		disableOsReload: disableOsReload,
+		featureOptions:  featureOptions,
 	}
 }
 
@@ -46,7 +46,7 @@ func (c *softLayerVirtualGuestCreator) Create(agentID string, stemcell bslcstem.
 	for _, network := range networks {
 		switch network.Type {
 		case "dynamic":
-			if cloudProps.DisableOsReload || c.disableOsReload {
+			if cloudProps.DisableOsReload || c.featureOptions.DisableOsReload {
 				return c.createBySoftlayer(agentID, stemcell, cloudProps, networks, env)
 			} else {
 				if len(network.IP) == 0 {

--- a/softlayer/vm/softlayer_virtual_guest_creator_test.go
+++ b/softlayer/vm/softlayer_virtual_guest_creator_test.go
@@ -43,6 +43,7 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 			softLayerClient,
 			agentOptions,
 			logger,
+			false,
 		)
 		bslcommon.TIMEOUT = 2 * time.Second
 		bslcommon.POLLING_INTERVAL = 1 * time.Second

--- a/softlayer/vm/softlayer_virtual_guest_creator_test.go
+++ b/softlayer/vm/softlayer_virtual_guest_creator_test.go
@@ -29,6 +29,7 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 		agentOptions    AgentOptions
 		logger          boshlog.Logger
 		creator         VMCreator
+		featureOptions  FeatureOptions
 	)
 
 	BeforeEach(func() {
@@ -55,19 +56,21 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 			BeforeEach(func() {
 				agentID = "fake-agent-id"
 				stemcell = bslcstem.NewSoftLayerStemcell(1234, "fake-stemcell-uuid", softLayerClient, logger)
+
+				env = Environment{}
+				featureOptions = FeatureOptions{DisableOsReload: false}
+
+				vmFinder.FindVM = fakevm.NewFakeVM(1234567)
+				vmFinder.FindFound = true
+				vmFinder.FindErr = nil
+
 				creator = NewSoftLayerCreator(
 					vmFinder,
 					softLayerClient,
 					agentOptions,
 					logger,
-					false,
+					featureOptions,
 				)
-
-				env = Environment{}
-
-				vmFinder.FindVM = fakevm.NewFakeVM(1234567)
-				vmFinder.FindFound = true
-				vmFinder.FindErr = nil
 			})
 			Context("creating vm by os_reload", func() {
 				Context("with dynamic networking", func() {
@@ -417,6 +420,8 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 
 				env = Environment{}
 
+				featureOptions = FeatureOptions{DisableOsReload: true}
+
 				vmFinder.FindVM = fakevm.NewFakeVM(1234567)
 				vmFinder.FindFound = true
 				vmFinder.FindErr = nil
@@ -426,7 +431,7 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 					softLayerClient,
 					agentOptions,
 					logger,
-					true,
+					featureOptions,
 				)
 			})
 

--- a/softlayer/vm/softlayer_virtual_guest_creator_test.go
+++ b/softlayer/vm/softlayer_virtual_guest_creator_test.go
@@ -38,13 +38,6 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 		logger = boshlog.NewLogger(boshlog.LevelNone)
 		vmFinder = &fakevm.FakeFinder{}
 
-		creator = NewSoftLayerCreator(
-			vmFinder,
-			softLayerClient,
-			agentOptions,
-			logger,
-			false,
-		)
 		bslcommon.TIMEOUT = 2 * time.Second
 		bslcommon.POLLING_INTERVAL = 1 * time.Second
 	})
@@ -58,10 +51,17 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 			env        Environment
 		)
 
-		Context("valid arguments", func() {
+		Context("valid arguments with os_reload enabled", func() {
 			BeforeEach(func() {
 				agentID = "fake-agent-id"
 				stemcell = bslcstem.NewSoftLayerStemcell(1234, "fake-stemcell-uuid", softLayerClient, logger)
+				creator = NewSoftLayerCreator(
+					vmFinder,
+					softLayerClient,
+					agentOptions,
+					logger,
+					false,
+				)
 
 				env = Environment{}
 
@@ -270,6 +270,65 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 						Expect(err).ToNot(HaveOccurred())
 						Expect(vm.ID()).To(Equal(1234567))
 					})
+
+					It("returns a new SoftLayerVM with ephemeral size", func() {
+						networks = map[string]Network{
+							"fake-network0": Network{
+								Type:    "dynamic",
+								IP:      "10.0.0.11",
+								Netmask: "fake-Netmask",
+								Gateway: "fake-Gateway",
+								DNS: []string{
+									"fake-dns0",
+									"fake-dns1",
+								},
+								Default:         []string{},
+								Preconfigured:   true,
+								CloudProperties: map[string]interface{}{},
+							},
+						}
+
+						cloudProps = VMCloudProperties{
+							StartCpus: 4,
+							MaxMemory: 2048,
+							Domain:    "fake-domain.com",
+							BlockDeviceTemplateGroup: sldatatypes.BlockDeviceTemplateGroup{
+								GlobalIdentifier: "fake-uuid",
+							},
+							RootDiskSize:                 25,
+							BoshIp:                       "10.0.0.1",
+							EphemeralDiskSize:            25,
+							Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
+							HourlyBillingFlag:            true,
+							LocalDiskFlag:                true,
+							VmNamePrefix:                 "bosh-test",
+							PostInstallScriptUri:         "",
+							DedicatedAccountHostOnlyFlag: true,
+							PrivateNetworkOnlyFlag:       false,
+							SshKeys:                      []sldatatypes.SshKey{{Id: 74826}},
+							BlockDevices: []sldatatypes.BlockDevice{{
+								Device:    "0",
+								DiskImage: sldatatypes.DiskImage{Capacity: 100}}},
+							NetworkComponents: []sldatatypes.NetworkComponents{{MaxSpeed: 1000}},
+							PrimaryNetworkComponent: sldatatypes.PrimaryNetworkComponent{
+								NetworkVlan: sldatatypes.NetworkVlan{Id: 524956}},
+							PrimaryBackendNetworkComponent: sldatatypes.PrimaryBackendNetworkComponent{
+								NetworkVlan: sldatatypes.NetworkVlan{Id: 524956}},
+							DisableOsReload: true,
+						}
+						expectedCmdResults := []string{
+							"",
+						}
+						sshClient.ExecCommandStub = func(_, _, _, _ string) (string, error) {
+							return expectedCmdResults[sshClient.ExecCommandCallCount()-1], nil
+						}
+						setFakeSoftlayerClientCreateObjectTestFixturesWithEphemeralDiskSize(softLayerClient)
+
+						vm, err := creator.Create(agentID, stemcell, cloudProps, networks, env)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(vm.ID()).To(Equal(1234567))
+					})
+
 					It("returns a new SoftLayerVM without ephemeral size", func() {
 						cloudProps = VMCloudProperties{
 							StartCpus: 4,
@@ -334,6 +393,167 @@ var _ = Describe("SoftLayer_Virtual_Guest_Creator", func() {
 								NetworkVlan: sldatatypes.NetworkVlan{Id: 524956}},
 							PrimaryBackendNetworkComponent: sldatatypes.PrimaryBackendNetworkComponent{
 								NetworkVlan: sldatatypes.NetworkVlan{Id: 524956}},
+						}
+
+						expectedCmdResults := []string{
+							"",
+						}
+						sshClient.ExecCommandStub = func(_, _, _, _ string) (string, error) {
+							return expectedCmdResults[sshClient.ExecCommandCallCount()-1], nil
+						}
+						setFakeSoftlayerClientCreateObjectTestFixturesWithoutBoshIP(softLayerClient)
+						vm, err := creator.Create(agentID, stemcell, cloudProps, networks, env)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(vm.ID()).To(Equal(1234567))
+					})
+				})
+			})
+		})
+
+		Context("valid arguments with os_reload disabled", func() {
+			BeforeEach(func() {
+				agentID = "fake-agent-id"
+				stemcell = bslcstem.NewSoftLayerStemcell(1234, "fake-stemcell-uuid", softLayerClient, logger)
+
+				env = Environment{}
+
+				vmFinder.FindVM = fakevm.NewFakeVM(1234567)
+				vmFinder.FindFound = true
+				vmFinder.FindErr = nil
+
+				creator = NewSoftLayerCreator(
+					vmFinder,
+					softLayerClient,
+					agentOptions,
+					logger,
+					true,
+				)
+			})
+
+			Context("creating vm in softlayer", func() {
+				Context("with dynamic networking", func() {
+					BeforeEach(func() {
+						networks = map[string]Network{
+							"fake-network0": Network{
+								Type:    "dynamic",
+								Netmask: "fake-Netmask",
+								Gateway: "fake-Gateway",
+								DNS: []string{
+									"fake-dns0",
+									"fake-dns1",
+								},
+								Default:         []string{},
+								Preconfigured:   true,
+								CloudProperties: map[string]interface{}{},
+							},
+						}
+					})
+
+					It("returns a new SoftLayerVM with ephemeral size", func() {
+						cloudProps = VMCloudProperties{
+							StartCpus: 4,
+							MaxMemory: 2048,
+							Domain:    "fake-domain.com",
+							BlockDeviceTemplateGroup: sldatatypes.BlockDeviceTemplateGroup{
+								GlobalIdentifier: "fake-uuid",
+							},
+							RootDiskSize:                 25,
+							BoshIp:                       "10.0.0.1",
+							EphemeralDiskSize:            25,
+							Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
+							HourlyBillingFlag:            true,
+							LocalDiskFlag:                true,
+							VmNamePrefix:                 "bosh-test",
+							PostInstallScriptUri:         "",
+							DedicatedAccountHostOnlyFlag: true,
+							PrivateNetworkOnlyFlag:       false,
+							SshKeys:                      []sldatatypes.SshKey{{Id: 74826}},
+							BlockDevices: []sldatatypes.BlockDevice{{
+								Device:    "0",
+								DiskImage: sldatatypes.DiskImage{Capacity: 100}}},
+							NetworkComponents: []sldatatypes.NetworkComponents{{MaxSpeed: 1000}},
+							PrimaryNetworkComponent: sldatatypes.PrimaryNetworkComponent{
+								NetworkVlan: sldatatypes.NetworkVlan{Id: 524956}},
+							PrimaryBackendNetworkComponent: sldatatypes.PrimaryBackendNetworkComponent{
+								NetworkVlan: sldatatypes.NetworkVlan{Id: 524956}},
+						}
+						expectedCmdResults := []string{
+							"",
+						}
+						sshClient.ExecCommandStub = func(_, _, _, _ string) (string, error) {
+							return expectedCmdResults[sshClient.ExecCommandCallCount()-1], nil
+						}
+						setFakeSoftlayerClientCreateObjectTestFixturesWithEphemeralDiskSize(softLayerClient)
+
+						vm, err := creator.Create(agentID, stemcell, cloudProps, networks, env)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(vm.ID()).To(Equal(1234567))
+					})
+					It("returns a new SoftLayerVM without ephemeral size", func() {
+						cloudProps = VMCloudProperties{
+							StartCpus: 4,
+							MaxMemory: 2048,
+							Domain:    "fake-domain.com",
+							BlockDeviceTemplateGroup: sldatatypes.BlockDeviceTemplateGroup{
+								GlobalIdentifier: "fake-uuid",
+							},
+							RootDiskSize:                 25,
+							BoshIp:                       "10.0.0.1",
+							Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
+							HourlyBillingFlag:            true,
+							LocalDiskFlag:                true,
+							VmNamePrefix:                 "bosh-test",
+							PostInstallScriptUri:         "",
+							DedicatedAccountHostOnlyFlag: true,
+							PrivateNetworkOnlyFlag:       false,
+							SshKeys:                      []sldatatypes.SshKey{{Id: 74826}},
+							BlockDevices: []sldatatypes.BlockDevice{{
+								Device:    "0",
+								DiskImage: sldatatypes.DiskImage{Capacity: 100}}},
+							NetworkComponents: []sldatatypes.NetworkComponents{{MaxSpeed: 1000}},
+							PrimaryNetworkComponent: sldatatypes.PrimaryNetworkComponent{
+								NetworkVlan: sldatatypes.NetworkVlan{Id: 524956}},
+							PrimaryBackendNetworkComponent: sldatatypes.PrimaryBackendNetworkComponent{
+								NetworkVlan: sldatatypes.NetworkVlan{Id: 524956}},
+						}
+						expectedCmdResults := []string{
+							"",
+						}
+						sshClient.ExecCommandStub = func(_, _, _, _ string) (string, error) {
+							return expectedCmdResults[sshClient.ExecCommandCallCount()-1], nil
+						}
+						setFakeSoftlayerClientCreateObjectTestFixturesWithoutEphemeralDiskSize(softLayerClient)
+						vm, err := creator.Create(agentID, stemcell, cloudProps, networks, env)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(vm.ID()).To(Equal(1234567))
+					})
+					It("returns a new SoftLayerVM without bosh ip", func() {
+						cloudProps = VMCloudProperties{
+							StartCpus: 4,
+							MaxMemory: 2048,
+							Domain:    "fake-domain.com",
+							BlockDeviceTemplateGroup: sldatatypes.BlockDeviceTemplateGroup{
+								GlobalIdentifier: "fake-uuid",
+							},
+							RootDiskSize:                 25,
+							EphemeralDiskSize:            25,
+							Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
+							HourlyBillingFlag:            true,
+							LocalDiskFlag:                true,
+							VmNamePrefix:                 "bosh-",
+							PostInstallScriptUri:         "",
+							DedicatedAccountHostOnlyFlag: true,
+							PrivateNetworkOnlyFlag:       false,
+							SshKeys:                      []sldatatypes.SshKey{{Id: 74826}},
+							BlockDevices: []sldatatypes.BlockDevice{{
+								Device:    "0",
+								DiskImage: sldatatypes.DiskImage{Capacity: 100}}},
+							NetworkComponents: []sldatatypes.NetworkComponents{{MaxSpeed: 1000}},
+							PrimaryNetworkComponent: sldatatypes.PrimaryNetworkComponent{
+								NetworkVlan: sldatatypes.NetworkVlan{Id: 524956}},
+							PrimaryBackendNetworkComponent: sldatatypes.PrimaryBackendNetworkComponent{
+								NetworkVlan: sldatatypes.NetworkVlan{Id: 524956}},
+							DisableOsReload: true,
 						}
 
 						expectedCmdResults := []string{


### PR DESCRIPTION
As os_reload behavior might prevent open source teams from really using this CPI, bosh-softlayer-cpi should honor some property from the CPI configuration or from the resource pool cloud properties which controls OS reload.  There are 2 approaches to disable os_reload function:
1. Indicate DisableOsReload flag in resource pool cloud properties:

```
resource_pools:
- cloud_properties:
    Bosh_ip: <%=director_ip%>
    Datacenter:
      Name: <%=data_center_name%>
    EphemeralDiskSize: 50
    HourlyBillingFlag: true
    LocalDiskFlag: true
    MaxMemory: 8192
    StartCpus: 4
    VmNamePrefix: <%=bluemix_env_name%>-core-
    DisableOsReload: true
  name: coreNode
  network: default
  size: 14
  stemcell:
    name: <%=stemcell%>
    version: <%=stemcell_version%>
```
1. Indicate DisableOsReload flag in cpi.json of softlayer_cpi job:

```
{
  "cloud": {
    "plugin": "softlayer",
    "properties": {
      "softlayer": {
        "username": "******",
        "apiKey": "******"
      },
      disableOsReload: true,
      "agent": {
        "ntp": [],
        "blobstore": {
          "provider": "dav",
          "options": {
            "endpoint": "http://127.0.0.1:25250",
            "user": "agent",
            "password": "agent"
          }
        },
        "mbus": "nats://nats:nats@127.0.0.1:4222"
      }
    }
  }
}
```
