### PR TITLE
Fix panics that happen in travis builds caused by port reuse in parallel tests

### DIFF
--- a/src/bosh-softlayer-cpi/softlayer/common/registry_agent_env_service_test.go
+++ b/src/bosh-softlayer-cpi/softlayer/common/registry_agent_env_service_test.go
@@ -9,9 +9,11 @@ import (
 	"net/http"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
 
 	. "bosh-softlayer-cpi/softlayer/common"
+
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 )
 
@@ -29,7 +31,7 @@ var _ = Describe("RegistryAgentEnvService", func() {
 
 		registryOptions := RegistryOptions{
 			Host:     "127.0.0.1",
-			Port:     6307,
+			Port:     6307 + GinkgoConfig.ParallelNode,
 			Username: "fake-username",
 			Password: "fake-password",
 		}


### PR DESCRIPTION
Use different server port for each node when running in parallel.

See https://travis-ci.org/cloudfoundry/bosh-softlayer-cpi/builds/193809087#L852